### PR TITLE
Use Object.keys instead of Ember.keys

### DIFF
--- a/addon/form-object.js
+++ b/addon/form-object.js
@@ -3,7 +3,8 @@ import DS from 'ember-data';
 import EmberValidations from 'ember-validations';
 import BufferedProxy from 'ember-buffered-proxy/proxy';
 
-const { computed, on, isEmpty, isNone, isPresent, keys, makeArray } = Ember;
+const { computed, on, isEmpty, isNone, isPresent, makeArray } = Ember;
+const { keys } = Object;
 
 export default BufferedProxy.extend(EmberValidations, Ember.Evented, {
   changes: computed.alias('buffer'),

--- a/tests/dummy/app/components/each-key.js
+++ b/tests/dummy/app/components/each-key.js
@@ -5,7 +5,7 @@ const { computed } = Ember;
 export default Ember.Component.extend({
   items: computed('object', function() {
     const object = this.get('object');
-    const keys   = Ember.keys(object);
+    const keys   = Object.keys(object);
 
     return Ember.A(keys.map(function(key) {
       const value = object[key];

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import formObject from 'ember-form-object/form-object-cp';
 
-const { keys } = Ember;
+const { keys } = Object;
 
 export default Ember.Controller.extend({
   data: formObject('model', {


### PR DESCRIPTION
`Ember.keys` is deprecated so we'll use `Object.keys` instead